### PR TITLE
Propagate axios error in API wrapper

### DIFF
--- a/node_modules/vue-lsi-util/APIAccesoV2.js
+++ b/node_modules/vue-lsi-util/APIAccesoV2.js
@@ -1,0 +1,51 @@
+import store from '@/store'
+import axios from 'axios'
+
+const AccesosAAPIV2 = {
+    async acceder (payload) {
+        return new Promise( 
+            function (resolve, reject) {
+                if (typeof(payload.Cartel)!=='undefined') {
+                    store.dispatch('loading/mostrar', payload.Cartel)
+                }
+                if (typeof(payload.Metodo)=="undefined") {
+                    payload.Metodo="GET"
+                }
+                if (typeof(payload.Cabeceras) === "undefined") {
+                    payload.Cabeceras = {};
+                }
+                if (typeof(payload.Credenciales) === "undefined") {
+                    payload.Credenciales = JSON.parse(process.env.VUE_APP_API).CredencialesV2
+                }
+                const prefijoURL=JSON.parse(process.env.VUE_APP_API).URLV2
+        
+                axios(
+                    {
+                        method: payload.Metodo, 
+                        url: prefijoURL+payload.Ruta, 
+                        headers: payload.Cabeceras, 
+                        data: payload.Body,
+                        auth: payload.Credenciales
+                    }
+                )
+                .then(datos => {
+                    if (datos.data.status.toUpperCase()=="OK") {
+                        resolve(datos.data.data)
+                    } else {
+                        reject(datos.data.errors)
+                    }
+                })
+                .catch(error => {
+                    reject(error)
+                })
+                .finally( () => {
+                    if (typeof(payload.Cartel)!=='undefined') {
+                        store.dispatch('loading/ocultar')
+                    }        
+                })
+            }
+        )
+    }
+}
+
+export default AccesosAAPIV2


### PR DESCRIPTION
## Summary
- ensure APIAccesoV2 forwards axios errors so callers can inspect response

## Testing
- `npm test` *(fails: build process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689ab580f150832ab78a29de8c9da8aa